### PR TITLE
chore: update GitHub Actions workflows for PyPI publishing and testing

### DIFF
--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -18,10 +18,10 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: "3.12"
+        version: 'latest'
       
     - name: Build a binary wheel and a source tarball
-      run: >-
-        uv build 
+      run: uv build 
 
     - name: Publish distribution to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -3,7 +3,7 @@ name: Pytest
 on:
   push:
     branches:
-      - '*'
+      - 'master'
     paths-ignore:
       - '*.md'
   pull_request:
@@ -28,6 +28,7 @@ jobs:
       uses: astral-sh/setup-uv@v6
       with:
         python-version: ${{ matrix.python-version }}
+        version: 'latest'
     
     - name: Install Dependencies for test group
       run: uv sync --group test


### PR DESCRIPTION
- Set Python version to 'latest' in both pypi-publish and pytest workflows.
- Restricted push events in pytest workflow to the 'master' branch only.
- Simplified the build command in the pypi-publish workflow.

## Summary by Sourcery

Update GitHub Actions workflows to use the latest Python version, restrict pytest triggering to master, and simplify the PyPI build step

CI:
- Add version: 'latest' to astral-sh/setup-uv in both pypi-publish and pytest workflows
- Restrict pytest workflow push events to the master branch
- Simplify the uv build command by removing YAML folding in the pypi-publish workflow